### PR TITLE
Correct english Hoenn contest ribbon descriptions

### DIFF
--- a/data/ribbons.json
+++ b/data/ribbons.json
@@ -71,7 +71,7 @@
 			"ko": "쿨리본하이퍼"
 		},
 		"descs": {
-			"en": "Hoenn Cool Contest Super Rank winner!",
+			"en": "Hoenn Cool Contest Hyper Rank winner!",
 			"es-es": "Concurso Carisma de Hoenn Ganador nivel avanzado.",
 			"fr": "Concours de Sang-froid de Hoenn Gagnant catégorie Hyper!",
 			"de": "Hoenn Coolness-Wettbewerb Sieger in der Hyper-Klasse!",
@@ -179,7 +179,7 @@
 			"ko": "뷰티리본하이퍼"
 		},
 		"descs": {
-			"en": "Hoenn Beauty Contest Super Rank winner!",
+			"en": "Hoenn Beauty Contest Hyper Rank winner!",
 			"es-es": "Concurso Belleza de Hoenn Ganador nivel avanzado.",
 			"fr": "Concours de Beauté de Hoenn Gagnant catégorie Hyper!",
 			"de": "Hoenn Schönheitswettbewerb Sieger in der Hyper-Klasse!",
@@ -287,7 +287,7 @@
 			"ko": "큐트리본하이퍼"
 		},
 		"descs": {
-			"en": "Hoenn Cute Contest Super Rank winner!",
+			"en": "Hoenn Cute Contest Hyper Rank winner!",
 			"es-es": "Concurso Dulzura de Hoenn Ganador nivel avanzado.",
 			"fr": "Concours de Grâce de Hoenn Gagnant catégorie Hyper!",
 			"de": "Hoenn Anmut-Wettbewerb Sieger in der Hyper-Klasse!",
@@ -395,7 +395,7 @@
 			"ko": "지니어스리본하이퍼"
 		},
 		"descs": {
-			"en": "Hoenn Smart Contest Super Rank winner!",
+			"en": "Hoenn Smart Contest Hyper Rank winner!",
 			"es-es": "Concurso Ingenio de Hoenn Ganador nivel avanzado.",
 			"fr": "Concours d'Intelligence de Hoenn Gagnant catégorie Hyper!",
 			"de": "Hoenn Klugheits-Wettbewerb Sieger in der Hyper-Klasse!",
@@ -503,7 +503,7 @@
 			"ko": "파워풀리본하이퍼"
 		},
 		"descs": {
-			"en": "Hoenn Tough Contest Super Rank winner!",
+			"en": "Hoenn Tough Contest Hyper Rank winner!",
 			"es-es": "Concurso Dureza de Hoenn Ganador nivel avanzado.",
 			"fr": "Concours de Robustesse de Hoenn Gagnant catégorie Hyper!",
 			"de": "Hoenn Stärke-Wettbewerb Sieger in der Hyper-Klasse!",


### PR DESCRIPTION
English Hyper contest ribbon descriptions are duplicate from the Super contest text.

Other locals appear to be correct.

<img width="437" height="258" alt="image" src="https://github.com/user-attachments/assets/6ac9fe98-7887-4943-8483-75f663c86a18" />
